### PR TITLE
Fix/diag cap

### DIFF
--- a/src/components/DiagnosticsCapture.tsx
+++ b/src/components/DiagnosticsCapture.tsx
@@ -119,7 +119,7 @@ export const DiagnosticsCapture = ({ namespace }: { namespace: string }) => {
             await runBash(`rm -rf ${temp_folder}`, { superuser: "require" });
             if (failedCommand) {
                 setErrorMessage(failedCommandMessage + "View console log for details.");
-            };
+            }
 
             setDownloadPath(archive_name);
         } catch (error) {


### PR DESCRIPTION
Address bug that sometimes interfered when Discovery Server was enabled and improve error handling so that if one command fails, the file is still served with the successful data.